### PR TITLE
Split single vs multiple mech variant text descriptions, UI updates

### DIFF
--- a/BTSimpleMechAssembly/SimpleMechAssembly_Main.cs
+++ b/BTSimpleMechAssembly/SimpleMechAssembly_Main.cs
@@ -309,11 +309,16 @@ namespace BTSimpleMechAssembly
 
             string selectedMechDisplayTitle = $"[[DM.MechDefs[{d.Description.Id}],{d.Chassis.VariantName}]] ({selectedMechParts} Parts/{numberOfChassisOwned} Complete)";
 
-            if (additionalVariants.Count() > 0)
+            if (additionalVariants.Count() > 1)
             {
-                desc += $"We can build the {selectedMechDisplayTitle}" +
-                    $", or one of these other variants of the {d.Chassis.Description.UIName}.\n\n";
+                desc += $"We can build the {selectedMechDisplayTitle}, " +
+                    $"or one of these other variants of the {d.Chassis.Description.UIName}:\n\n";
                 desc += string.Join("\n", additionalVariants);
+                VariantPopup(desc, s, ownedMechVariantParts, refresh, close);
+            } else if (additionalVariants.Count() == 1)
+            {
+                desc += $"We can build the {selectedMechDisplayTitle}, or the\n" +
+                    $"{string.Join("", additionalVariants)} variant of the {d.Chassis.Description.UIName}.";
                 VariantPopup(desc, s, ownedMechVariantParts, refresh, close);
             }
             else


### PR DESCRIPTION

* remove duplication among displayed chassis UIName & variants
* differentiate single vs multiple mech build options
* substring button text to variant to help with text overflow
* capitalize "I" in a couple places
* consistent cancel button text
* add CancelOnEscape


![20200704124939_1](https://user-images.githubusercontent.com/67759531/86520257-167bb800-bdf7-11ea-9423-875d86732f74.jpg)
![20200704124915_1](https://user-images.githubusercontent.com/67759531/86520258-17144e80-bdf7-11ea-83c3-616467121ac8.jpg)
![20200704125020_1](https://user-images.githubusercontent.com/67759531/86520255-14b1f480-bdf7-11ea-9efe-938b41a2a693.jpg)

